### PR TITLE
Add python3 to nix deps after the corresponding commit was lost in merge

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,5 +5,6 @@ pkgs.mkShell {
     nodejs
     mupdf
     imagemagick
+    python3
   ];
 }


### PR DESCRIPTION
Seems like the python3 commit was forgotten in the merge (perhaps a broken squash)

next PR to follow with a fix for westermann login #25