### PR TITLE
Fix Windows install (drop native iconv), modernize dependencies, target Node LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,18 +2,20 @@
   "dependencies": {
     "adm-zip": "^0.5.10",
     "axios": "^1.7.5",
-    "axios-cookiejar-support": "^5.0.2",
+    "axios-cookiejar-support": "^7.0.0",
     "ebookdownloader": "file:",
-    "iconv": "^3.0.1",
-    "image-size": "^1.0.2",
-    "node-html-parser": "^2.1.0",
+    "iconv-lite": "^0.7.2",
+    "image-size": "^2.0.2",
+    "node-html-parser": "^7.1.0",
     "pdf-lib": "^1.17.1",
-    "pdfkit": "^0.11.0",
+    "pdfkit": "^0.18.0",
     "prompts": "^2.4.0",
-    "querystring": "^0.2.0",
-    "tough-cookie": "^4.1.4",
-    "transformation-matrix": "^2.13.0",
+    "tough-cookie": "^6.0.1",
+    "transformation-matrix": "^3.1.0",
     "xml2js": "^0.6.2"
+  },
+  "devDependencies": {
+    "@yao-pkg/pkg": "^6.20.0"
   },
   "bin": "EbookDownloader.js",
   "pkg": {
@@ -21,7 +23,9 @@
       "node_modules/**/*"
     ],
     "targets": [
-      "node14-win-x64"
+      "node20-win-x64",
+      "node22-win-x64",
+      "node24-win-x64"
     ]
   },
   "name": "ebookdownloader",

--- a/src/EbookDownloader.js
+++ b/src/EbookDownloader.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('./lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');

--- a/src/downloader/allango.js
+++ b/src/downloader/allango.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');

--- a/src/downloader/book2look.js
+++ b/src/downloader/book2look.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');

--- a/src/downloader/clicknstudy.js
+++ b/src/downloader/clicknstudy.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');
@@ -190,7 +190,7 @@ function clicknstudy(email, passwd, deleteAllOldTempImages) {
             dir.sort().forEach((file, idx) => {
                 doc.addPage();
                 doc.rect(0, 0, size[0], size[1]).fill("#000000");
-                var thissize = sizeOf(folder + file);
+                var thissize = sizeOf(fs.readFileSync(folder + file));
                 var thissizefitted = {
                     width: Math.min(size[0] / thissize.width, size[1] / thissize.height) * thissize.width,
                     height: Math.min(size[0] / thissize.width, size[1] / thissize.height) * thissize.height

--- a/src/downloader/clicknteach.js
+++ b/src/downloader/clicknteach.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');
@@ -190,7 +190,7 @@ function clicknteach(email, passwd, deleteAllOldTempImages) {
             dir.sort().forEach((file, idx) => {
                 doc.addPage();
                 doc.rect(0, 0, size[0], size[1]).fill("#000000");
-                var thissize = sizeOf(folder + file);
+                var thissize = sizeOf(fs.readFileSync(folder + file));
                 var thissizefitted = {
                     width: Math.min(size[0] / thissize.width, size[1] / thissize.height) * thissize.width,
                     height: Math.min(size[0] / thissize.width, size[1] / thissize.height) * thissize.height

--- a/src/downloader/cornelsen.js
+++ b/src/downloader/cornelsen.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');

--- a/src/downloader/klett.js
+++ b/src/downloader/klett.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');

--- a/src/downloader/scook.js
+++ b/src/downloader/scook.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');

--- a/src/downloader/westermann.js
+++ b/src/downloader/westermann.js
@@ -10,8 +10,8 @@ const prompts = require('prompts');
 const https = require('https')
 const crypto = require('crypto')
 var spawn = require('child_process').spawn
-var Iconv = require('iconv').Iconv;
-const sizeOf = require('image-size')
+var Iconv = require('../lib/iconv').Iconv;
+const sizeOf = require('image-size').imageSize
 const pdflib = require("pdf-lib")
 
 var HTMLParser = require('node-html-parser');

--- a/src/lib/iconv.js
+++ b/src/lib/iconv.js
@@ -1,0 +1,28 @@
+// Pure-JS drop-in replacement for the native `iconv` package's `Iconv` class.
+//
+// The native `iconv` module requires node-gyp + a C++ toolchain (Visual Studio
+// on Windows) to compile. `iconv-lite` is pure JavaScript and needs no build
+// step, so we wrap it to expose the same `new Iconv(from, to).convert(buf)` API
+// the codebase already uses.
+var iconvLite = require('iconv-lite');
+
+// `iconv-lite` does not understand GNU iconv suffixes like `//TRANSLIT` or
+// `//IGNORE`, so strip them down to the base encoding name.
+function normalizeEncoding(encoding) {
+    return String(encoding).split('//')[0].trim();
+}
+
+function Iconv(fromEncoding, toEncoding) {
+    this.fromEncoding = normalizeEncoding(fromEncoding);
+    this.toEncoding = normalizeEncoding(toEncoding);
+}
+
+// Mirrors node-iconv: `input` may be a Buffer or a string (treated as UTF-8
+// bytes). Returns a Buffer encoded in `toEncoding`.
+Iconv.prototype.convert = function convert(input) {
+    var buffer = Buffer.isBuffer(input) ? input : Buffer.from(input, 'utf8');
+    var decoded = iconvLite.decode(buffer, this.fromEncoding);
+    return iconvLite.encode(decoded, this.toEncoding);
+};
+
+module.exports = { Iconv: Iconv };


### PR DESCRIPTION
## Summary
- Replace native `iconv` with pure-JS `iconv-lite` via a small `Iconv`-compatible shim, so `npm install` no longer requires node-gyp + Visual Studio C++ build tools on Windows.
- Bump all dependencies to latest; this also clears a critical `crypto-js` advisory pulled in transitively by `pdfkit` (now 0.18).
- Migrate `image-size` to v2 (named `imageSize` export, Buffer-only input).
- Drop the redundant `querystring` dependency (it is a Node built-in).
- Switch the `pkg` build to the maintained `@yao-pkg/pkg` fork and target current Node LTS (20/22/24) instead of EOL node14.

## Why
A fresh `npm install` on Windows failed with a node-gyp / "Could not find any Visual Studio installation" error, because `iconv@3` is a native module. The pure-JS replacement removes the toolchain requirement entirely.

## Notes
- `iconv` is only actively used in `klett.js`; the shim keeps the existing `new Iconv(from, to).convert(buf)` API so call sites are unchanged.
- `image-size` v2 dropped file-path input, so the two call sites now pass a Buffer via `fs.readFileSync(...)`.

## Testing
- `npm install` completes with 0 vulnerabilities (Node 26 / Windows 11).
- All downloader modules load; smoke-tested pdfkit PDF generation, `imageSize`, and `transformation-matrix` against the upgraded versions.