### PR TITLE
Add table of contents to click and study books

### DIFF
--- a/src/downloader/clicknstudy.js
+++ b/src/downloader/clicknstudy.js
@@ -271,32 +271,28 @@ function clicknstudy(email, passwd, deleteAllOldTempImages) {
                 }
             })
 
-            if (chapterRoots.length > 0) {
+            if (chapterRoots.length > 0 && dir.length > 0) {
                 console.log("Adding table of contents");
-                var pageIndexByName = {};
-                for (var i = 0; i <= bookData.endPage - bookData.startPage; i++) {
-                    var label = i + bookData.startPage - bookData.pageOffset;
-                    if (label <= 0) label = pageOffsetLabelsRev[i + bookData.startPage];
-                    if (pageIndexByName[label] == null) pageIndexByName[label] = i;
-                }
                 function getPageIndex(pagenum) {
                     if (pagenum == null || pagenum === "") return null;
-                    var name = String(pagenum);
-                    if (pageIndexByName[name] != null) return pageIndexByName[name];
-                    var num = parseInt(name, 10);
-                    if (Number.isInteger(num)) {
-                        for (var i = 0; i <= bookData.endPage - bookData.startPage; i++) {
-                            var label = i + bookData.startPage - bookData.pageOffset;
-                            if (label <= 0) label = pageOffsetLabelsRev[i + bookData.startPage];
-                            if (parseInt(label, 10) >= num) return i;
-                        }
+                    var num = parseInt(pagenum, 10);
+                    if (!Number.isInteger(num)) return null;
+                    var viewerIndex = num - bookData.pageOffset;
+                    if (bookData.pageOffsetLabels[viewerIndex] != null) {
+                        viewerIndex = bookData.pageOffsetLabels[viewerIndex];
+                    } else {
+                        viewerIndex += bookData.pageOffset;
                     }
-                    return null;
+                    viewerIndex -= bookData.startPage;
+                    return Number.isInteger(viewerIndex) ? viewerIndex : null;
                 }
                 function addOutline(parent, chapters) {
-                    chapters.filter(chapter => chapter.title).forEach(chapter => {
+                    chapters.forEach(chapter => {
+                        if (!chapter.title) return;
                         var pageIndex = getPageIndex(chapter.page);
-                        if (pageIndex == null || pageIndex >= dir.length) pageIndex = dir.length - 1;
+                        if (pageIndex == null) return;
+                        if (pageIndex < 0) pageIndex = 0;
+                        if (pageIndex >= dir.length) pageIndex = dir.length - 1;
                         var item = parent.addItem(chapter.title, { pageNumber: pageIndex, fit: true });
                         if (chapter.children && chapter.children.length > 0) {
                             addOutline(item, chapter.children);

--- a/src/downloader/clicknstudy.js
+++ b/src/downloader/clicknstudy.js
@@ -108,6 +108,32 @@ function clicknstudy(email, passwd, deleteAllOldTempImages) {
 
             var pageOffsetLabelsRev = Object.entries(bookData.pageOffsetLabels).reduce((result, value) => ({ ...result, [value[1]]: value[0] }), {});
 
+            var chapterRoots = (function parseTableOfContents(html) {
+                var root = HTMLParser.parse(html);
+                var items = root.querySelectorAll("#panel-left .register li");
+                var byId = {};
+                items.forEach(li => {
+                    var pageLink = li.querySelector(".pageLink");
+                    var titleEl = pageLink ? pageLink.querySelector(".title") : null;
+                    byId[li.getAttribute("data-id")] = {
+                        title: titleEl ? titleEl.text.trim() : "",
+                        page: pageLink ? pageLink.getAttribute("data-page") : null,
+                        children: [],
+                    };
+                });
+                var roots = [];
+                items.forEach(li => {
+                    var node = byId[li.getAttribute("data-id")];
+                    var parent = li.getAttribute("data-parent");
+                    if (parent && parent !== "0" && byId[parent]) {
+                        byId[parent].children.push(node);
+                    } else {
+                        roots.push(node);
+                    }
+                });
+                return roots;
+            })(res.data);
+
             var name = bookData.bookName.replace(/[^a-za-z0-9 \(\)_\-,\.]/gi, '');
             var folder = ("./out/DownloadTemp/" + name + "/");
             if (deleteAllOldTempImages && fs.existsSync(folder)) fs.rmSync(folder, {
@@ -244,6 +270,41 @@ function clicknstudy(email, passwd, deleteAllOldTempImages) {
                     doc.restore()
                 }
             })
+
+            if (chapterRoots.length > 0) {
+                console.log("Adding table of contents");
+                var pageIndexByName = {};
+                for (var i = 0; i <= bookData.endPage - bookData.startPage; i++) {
+                    var label = i + bookData.startPage - bookData.pageOffset;
+                    if (label <= 0) label = pageOffsetLabelsRev[i + bookData.startPage];
+                    if (pageIndexByName[label] == null) pageIndexByName[label] = i;
+                }
+                function getPageIndex(pagenum) {
+                    if (pagenum == null || pagenum === "") return null;
+                    var name = String(pagenum);
+                    if (pageIndexByName[name] != null) return pageIndexByName[name];
+                    var num = parseInt(name, 10);
+                    if (Number.isInteger(num)) {
+                        for (var i = 0; i <= bookData.endPage - bookData.startPage; i++) {
+                            var label = i + bookData.startPage - bookData.pageOffset;
+                            if (label <= 0) label = pageOffsetLabelsRev[i + bookData.startPage];
+                            if (parseInt(label, 10) >= num) return i;
+                        }
+                    }
+                    return null;
+                }
+                function addOutline(parent, chapters) {
+                    chapters.filter(chapter => chapter.title).forEach(chapter => {
+                        var pageIndex = getPageIndex(chapter.page);
+                        if (pageIndex == null || pageIndex >= dir.length) pageIndex = dir.length - 1;
+                        var item = parent.addItem(chapter.title, { pageNumber: pageIndex, fit: true });
+                        if (chapter.children && chapter.children.length > 0) {
+                            addOutline(item, chapter.children);
+                        }
+                    });
+                }
+                addOutline(doc.outline, chapterRoots);
+            }
 
             doc.end()
             console.log("Wrote ./out/" + name + ".pdf")


### PR DESCRIPTION
Closes #70 
Adds the ToC to Click & Study PDFs like with westermann
Example:
<img width="575" height="902" alt="image" src="https://github.com/user-attachments/assets/43b5c23b-9e70-4eb4-9613-294731bc6b73" />
